### PR TITLE
[HOTFIX] resolve 403 error in ticket consumption API - PIT - 639

### DIFF
--- a/src/main/java/PitterPetter/loventure/gateway/dto/ApiResponse.java
+++ b/src/main/java/PitterPetter/loventure/gateway/dto/ApiResponse.java
@@ -1,0 +1,23 @@
+package PitterPetter.loventure.gateway.dto;
+
+public record ApiResponse<T>(
+    String status,
+    String message,
+    T data
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", "Success", data);
+    }
+    
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>("success", message, data);
+    }
+    
+    public static <T> ApiResponse<T> error(String status, String message) {
+        return new ApiResponse<>(status, message, null);
+    }
+    
+    public static <T> ApiResponse<T> error(String status, String message, T data) {
+        return new ApiResponse<>(status, message, data);
+    }
+}


### PR DESCRIPTION
- Add ApiResponse DTO class to match Auth Service response format
- Update CouplesApiClient.consumeTicket() to handle ApiResponse<Boolean> instead of Boolean
- Fix JSON deserialization error that was causing 403 Forbidden responses
- Improve error handling for ticket consumption failures

This resolves the issue where region unlock requests were failing with 403 errors due to incorrect response parsing in the Gateway service.

## 📝 목적/배경
- 왜 이 변경이 필요한가? 어떤 문제를 해결하는가?

## 🔧 주요 작업(변경) 사항
- [ ] 

## 🎥 스크린샷/데모 (선택)
<이미지 또는 gif>

## 🔗 이슈 연결
- PIT-~~

## ✅ 체크리스트
- [ ] merge branch 가 develop 인지 확인
- [ ] 모든 코드가 잘 작동하는지 확인
- [ ] 모두가 알아 볼 수 있도록 작성 되어 있는지

## 📌 기타
